### PR TITLE
feat: add eslint to the build process

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+// Use this file as a starting point for your project's .eslintrc.
+// Copy this file, and add rule overrides as needed.
+{
+  "extends": "airbnb"
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 // Use this file as a starting point for your project's .eslintrc.
 // Copy this file, and add rule overrides as needed.
 {
-  "extends": "standard"
+  "extends": ["standard", "plugin:react/recommended"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 // Use this file as a starting point for your project's .eslintrc.
 // Copy this file, and add rule overrides as needed.
 {
-  "extends": "airbnb"
+  "extends": "standard"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  webpack: (config, { dev }) => {
+    if (!dev) {
+        return config
+    }
+
+    const rules = config.module.rules;
+    const lintConfig = {
+        test: /\.js(\?[^?]*)?$/,
+        loader: 'eslint-loader',
+        exclude: /node_modules/
+    };
+    rules.push(lintConfig);
+    
+    return config
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint": "^3.19.0",
     "eslint-loader": "^1.7.1",
     "eslint-config-standard": "^10.2.0",
+    "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "shortid": "^2.2.8"
   },
   "devDependencies": {
-    "babel-eslint": "^7.2.1",
     "eslint": "^3.19.0",
-    "eslint-config-airbnb": "^14.1.0",
     "eslint-loader": "^1.7.1",
+    "eslint-config-standard": "^10.2.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.3"
+    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,14 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "shortid": "^2.2.8"
+  },
+  "devDependencies": {
+    "babel-eslint": "^7.2.1",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-loader": "^1.7.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.3"
   }
 }


### PR DESCRIPTION
I used [this](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) to set the rules to airbnb spec. It imports a couple other style guides as well. A glance at the output reveals a few things that raise an eyebrow.

> Expected indentation of 6 space characters but found 4 - react/jsx-indent

We can just update the .editorconfig to support this.

> JSX not allowed in files with extension '.js' - react/jsx-filename-extension

This is probably more controversial. I don't really have any skin in this game, but I would probably skip this one because the Next configuration would probably _dislike_ this.