### PR TITLE
Clear warnings for missing keys and React.PropTypes deprecation

### DIFF
--- a/components/navLink.js
+++ b/components/navLink.js
@@ -1,5 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Link from 'next/link'
+import shortid from 'shortid'
 
 const navigationLinks = [
   { name: 'Home', link: '/', router: true },
@@ -22,18 +24,18 @@ const SimpleLink = ({ link }) => (
 )
 
 const RenderLink = link => link.router
-  ? (<NextLink link={link} />)
-  : (<SimpleLink link={link} />)
+  ? (<NextLink link={link} key={shortid.generate()} />)
+  : (<SimpleLink link={link} key={shortid.generate()} />)
 
 NextLink.propTypes = {
-  link: React.PropTypes.shape({
-    link: React.PropTypes.string.isRequired
+  link: PropTypes.shape({
+    link: PropTypes.string.isRequired
   })
 }
 
 SimpleLink.propTypes = {
-  link: React.PropTypes.shape({
-    link: React.PropTypes.string.isRequired
+  link: PropTypes.shape({
+    link: PropTypes.string.isRequired
   })
 }
 


### PR DESCRIPTION
The NavLink refactoring (which was great -- I learned a couple things from it) introduced two warnings: one for missing keys and another for the deprecation of React.PropTypes in favor of the prop-types package. I updated navLinks.js to clear the warnings.